### PR TITLE
docs: use Roguelike Toolkit (RLTK) for titles

### DIFF
--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.sark.rltk_unity",
-  "displayName": "RLTK",
+  "displayName": "Roguelike Toolkit (RLTK)",
   "version": "0.2.9",
   "unity": "2019.3",
   "unityRelease": "0f6",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RLTK for Unity
+# The Roguelike Toolkit (RLTK) for Unity
 
 This is a framework built specifically for creating roguelikes and rendering ascii efficiently and without artifacts inside Unity. While the API is made to be as simple and straightforward as possible, internally it utilizes Unity's Job system and Burst compiler to achieve great performance and avoid any memory allocations whenever possible.
 
@@ -13,12 +13,12 @@ RLTK for Unity will always be free and the code will always be open source. With
 
 
 ![](./Assets/Documentation/images~/splash.png)
- 
+
 ## The Samples
 
 The samples demonstrate how to properly set up and write to a console.
 
-##### Samples/Noise 
+##### Samples/Noise
 
 ![](./Assets/Documentation/images~/noise.gif)
 
@@ -37,7 +37,7 @@ There are three primary console types, `SimpleConsole`, `NativeConsole` and `Sim
   * Must manually call `Draw()` and `Update()` every frame to render it.
   * Must call manually `Dispose()` before it goes out of scope to free internal [unmanaged memory](https://docs.unity3d.com/ScriptReference/Unity.Collections.NativeArray_1.html).
 
- 
+
 
 ##### [NativeConsole](Assets/Runtime/RLTK/Consoles/NativeConsole.cs) - Usage is demonstrated in the "Noise" sample.
   * Derived from `SimpleConsole`, provides a few more advanced functions for those familiar with Unity's [job system](https://docs.unity3d.com/2019.3/Documentation/Manual/JobSystem.html).
@@ -46,7 +46,7 @@ There are three primary console types, `SimpleConsole`, `NativeConsole` and `Sim
 ##### [SimpleConsoleProxy](Assets/Runtime/RLTK/MonoBehaviours/SimpleConsoleProxy.cs) - Usage is demonstrated in the "Hello World" sample.
   * A MonoBehaviour wrapped around a `SimpleConsole`. Allows you to easily reference and write to a console from other MonoBehaviours.
   * Console properties can be tweaked from the inspector.
-  * No need to call `Dispose()` or `Draw()`. 
+  * No need to call `Dispose()` or `Draw()`.
   * Can be set up automatically using the menu option `GameObject/RLTK/Initialize Simple Console`.
 
 
@@ -57,7 +57,7 @@ There are three primary console types, `SimpleConsole`, `NativeConsole` and `Sim
 If you're using SimpleConsoleProxy you can use the [LockCameraToConsole](Assets/Runtime/RLTK/Monobehaviours/LockCameraToConsole.cs) MonoBehaviour instead.
 
 ## What does it do
-* You can write to a console with the `Set` and `Print` functions, or retrieve the native tiles from the console for use directly inside jobs. Consoles are fast enough to clear and draw a large number of tiles every frame, the way you would in a traditional roguelike. 
+* You can write to a console with the `Set` and `Print` functions, or retrieve the native tiles from the console for use directly inside jobs. Consoles are fast enough to clear and draw a large number of tiles every frame, the way you would in a traditional roguelike.
 * There are field of view functions in the `FOV` class.
 
 ## How to use it
@@ -68,20 +68,19 @@ Along with RLTK I am [developing a Roguelike that uses RLTK as a backend](https:
 
 
 ## How to get it
-The recommended way to use this package is via the Unity Package Manager. At the top left 
-of the package manager, click the "+" button and choose "Add package from git url...". 
+The recommended way to use this package is via the Unity Package Manager. At the top left
+of the package manager, click the "+" button and choose "Add package from git url...".
 Then paste in `https://github.com/sarkahn/rltk_unity.git#upm`
 and you should be good to go.
 
 ![](./Assets/Documentation/images~/upm.gif)
 
-This will automatically install the package and all required dependencies. **You can import 
+This will automatically install the package and all required dependencies. **You can import
 the built in samples from the package manager UI once it's installed**.
 
-If you need to update RLTK you can remove and re-install it via the package manager or delete 
+If you need to update RLTK you can remove and re-install it via the package manager or delete
 this section from the "Packages/manifest.json" file in your project root folder:
 
 ![](Assets/Documentation/images~/manifest.png)
 
 That will cause the package manager to automatically update to the latest version.
-


### PR DESCRIPTION
I would suggest to use "Roguelike Toolkit (RLTK)“ for titles for better discoverability.

Also fixed trivial white space issue.